### PR TITLE
fix: poetry shell was moved to a plugin

### DIFF
--- a/.devcontainer/Readme.md
+++ b/.devcontainer/Readme.md
@@ -53,6 +53,7 @@ It has optional support for **TensorFlow** and **PyTorch** on **GPU** enabled ma
 | **❌ Error**                                                | **✅ Solution**                                                                |
 | :---------------------------------------------------------- | :----------------------------------------------------------------------------- |
 | Shell scripts fail to run or complain about `\r` characters | Check if the `End of Line` formatting of the scripts is set to `LF` in VSCode. |
+| `poetry shell` fails or is not recognized as a command    | Poetry shell was moved to a plugin (January 2025). Run `pip install poetry-plugin-shell` in the terminal. |
 
 ## Versioning
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,8 +17,8 @@
     // A GPU-enabled container requires the NVIDIA CUDA Toolkit (contains cuFFT, cuBLAS, etc.) and cuDNN in the container itself
     // For compatible version combinations check https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/
     "ghcr.io/devcontainers/features/nvidia-cuda:1": {
-      "installToolkit": false,
-      "installCudnn": false,
+      "installToolkit": true,
+      "installCudnn": true,
       "cudaVersion": "12.6",
       "cudnnVersion": "9.5.0.50"
     },

--- a/.devcontainer/scripts/create_python_env.sh
+++ b/.devcontainer/scripts/create_python_env.sh
@@ -39,6 +39,7 @@ venv_add_tensorflow() {
 clear
 echo "⚙️  Instaling dependencies..."
 python -m pip install poetry --no-warn-script-location --root-user-action=ignore  >> .devcontainer/logs.log
+python -m pip install poetry-plugin-shell --no-warn-script-location --root-user-action=ignore  >> .devcontainer/logs.log
 poetry install >> .devcontainer/logs.log
 
 # Ask if the user wants to create a PyTorch environment

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ It has optional support for **TensorFlow** and **PyTorch** on **GPU** enabled ma
 | **❌ Error**                                                | **✅ Solution**                                                                |
 | :---------------------------------------------------------- | :----------------------------------------------------------------------------- |
 | Shell scripts fail to run or complain about `\r` characters | Check if the `End of Line` formatting of the scripts is set to `LF` in VSCode. |
+| `poetry shell` fails or is not recognized as a command    | Poetry shell was moved to a plugin (January 2025). Run `pip install poetry-plugin-shell` in the terminal. |
 
 ## Versioning
 


### PR DESCRIPTION
- Poetry shell was moved to a seperate pip-installable plugin as of January 2025. This plugin now gets installed automatically after creating a new container.
- The NVIDIA CUDA image was included in the `devcontainer.json` template by default, but the `installToolkit` and `installCudnn` settings were set to `false`. I changed this to be `true` by default since most of our projects can benefit from GPU-acceleration.